### PR TITLE
support dialects that don't support ordinal ordering

### DIFF
--- a/macros/one_hot_encoder.sql
+++ b/macros/one_hot_encoder.sql
@@ -6,7 +6,7 @@
                 {{ source_column }}
             from
                 {{ source_table }}
-            order by 1
+            order by {{ source_column }}
         {% endset %}
         {% set results = run_query(category_values_query) %}
         {% if execute %}


### PR DESCRIPTION
TSQL does not support ordinal ordering, i.e., `ORDER BY 1`. Fortunately, there is only one usage to this in the whole package.

Check out https://github.com/fishtown-analytics/dbt-utils/pull/310 for more examples