### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then run:
 ```dbt deps``` to import the package.
 
 ### dbt 1.0.0 compatibility
-dbt-ml-preprocessing version 1.2.0 is the first version to support (and require) dbt 1.0.0.
+dbt-ml-preprocessing version 1.1.0 is the first version to support (and require) dbt 1.0.0.
 
 If you are not ready to upgrade to dbt 1.0.0, please use dbt-ml-preprocessing version 1.0.2.
 


### PR DESCRIPTION
Either I'm wrong and version 1.2.0 is not released yet/forgotten to bump version, or it was meant to be 1.1.0